### PR TITLE
Bitrise flavor SSH key activator revision

### DIFF
--- a/steps/activate-ssh-key_flavor_bitrise/2.0.0/step.yml
+++ b/steps/activate-ssh-key_flavor_bitrise/2.0.0/step.yml
@@ -1,6 +1,6 @@
 ---
 name: |
-  Activate SSH key (RSA private key)
+  Activate App SSH key
 description: |
   Saves the provided **RSA private SSH key** to file
   and then loads it into the user's ssh-agent with `ssh-add`.


### PR DESCRIPTION
removed the auto-injected inputs and renamed the step (title)
